### PR TITLE
Add basic quiz website with random questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# llm-quiz-time
+# LLM Quiz Time
+
+A simple web-based quiz app that shows a random question on each refresh.
+
+## Usage
+Open `index.html` in your browser. The page fetches questions from `questions.json` and displays one randomly.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,18 @@
+async function loadQuestion() {
+    const res = await fetch('questions.json');
+    const data = await res.json();
+    const q = data[Math.floor(Math.random() * data.length)];
+    const questionDiv = document.getElementById('question');
+    const optionsDiv = document.getElementById('options');
+
+    questionDiv.textContent = q.question;
+    optionsDiv.innerHTML = '';
+    q.options.forEach(opt => {
+        const div = document.createElement('div');
+        div.className = 'option';
+        div.textContent = opt;
+        optionsDiv.appendChild(div);
+    });
+}
+
+window.addEventListener('DOMContentLoaded', loadQuestion);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LLM Quiz Time</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <div class="quiz-tile" id="quiz">
+            <div class="question" id="question"></div>
+            <div class="options" id="options"></div>
+        </div>
+    </div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/questions.json
+++ b/questions.json
@@ -1,0 +1,22 @@
+[
+    {
+        "question": "What does LLM stand for?",
+        "options": ["Large Language Model", "Long Lengthy Module", "Light Logic Machine", "Local Link Map"]
+    },
+    {
+        "question": "Which company created GPT-4?",
+        "options": ["OpenAI", "Google", "Meta", "IBM"]
+    },
+    {
+        "question": "What is the time complexity of binary search?",
+        "options": ["O(log n)", "O(n)", "O(n^2)", "O(1)"]
+    },
+    {
+        "question": "Which language runs in a web browser?",
+        "options": ["JavaScript", "Python", "C++", "Java"]
+    },
+    {
+        "question": "What year was the C programming language developed?",
+        "options": ["1972", "1980", "1965", "1991"]
+    }
+]

--- a/style.css
+++ b/style.css
@@ -1,0 +1,43 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: "Courier New", monospace;
+    background: #0d0d0d;
+    color: #f1f1f1;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    text-align: center;
+}
+
+.quiz-tile {
+    background: #1e1e1e;
+    padding: 2rem;
+    border-radius: 10px;
+    box-shadow: 0 0 10px #39ff14;
+    max-width: 400px;
+    width: 90%;
+}
+
+.question {
+    font-size: 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.option {
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    background: #2e2e2e;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.option:hover {
+    background: #39ff14;
+    color: #000;
+}


### PR DESCRIPTION
## Summary
- add a minimal interactive quiz page in `index.html`
- style the page with a dark, neon theme
- implement `app.js` to load a random question from `questions.json`
- store sample questions in `questions.json`
- update `README` with usage instructions

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('questions.json','utf8')); console.log('JSON OK')"`

------
https://chatgpt.com/codex/tasks/task_e_686b668fdbf083208b4ec2af02a41c67