### PR TITLE
Fix missing env in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ concurrency:
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- specify the `github-pages` environment for deployment

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b6a9e6e98832097b3995c19ee4266