### PR TITLE
Fix GitHub Pages subpath handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,12 @@ Open `index.html` in your browser. The page fetches questions from
 
 ## Deployment
 The repository includes a GitHub Actions workflow that publishes the contents of
-the `main` branch to GitHub Pages. Push changes to `main` and they will be
-available at [https://llmquiz.github.io](https://llmquiz.github.io).
+the `main` branch to GitHub Pages. Because this repository is not named
+`llmquiz.github.io`, the site is served from the repository subpath. After
+pushing to `main`, the website will be available at
+[https://llmquiz.github.io/llm-quiz-time/](https://llmquiz.github.io/llm-quiz-time/)
+(note the trailing `/`).
+
+If the page still returns a 404, verify that GitHub Pages is enabled for this
+repository with **GitHub Actions** selected as the source. The `pages-build-deployment`
+workflow must complete successfully before the site becomes accessible.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LLM Quiz Time</title>
+    <!-- Ensure paths resolve when served from a repository subpath -->
+    <base href="/llm-quiz-time/">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add `<base>` tag so the site works when hosted from a repo subpath
- expand README deployment instructions and note trailing slash

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b6be135a08320a4397c6f031012d4