### PR TITLE
Show random question on load

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,16 @@ async function loadData() {
         btn.addEventListener('click', () => loadQuestion(topic));
         topicsDiv.appendChild(btn);
     });
+
+    // Display a random question on initial load
+    loadRandomQuestion();
+}
+
+function loadRandomQuestion() {
+    const topics = Object.keys(questions);
+    if (topics.length === 0) return;
+    const randomTopic = topics[Math.floor(Math.random() * topics.length)];
+    loadQuestion(randomTopic);
 }
 
 function loadQuestion(topic) {

--- a/style.css
+++ b/style.css
@@ -12,6 +12,9 @@ body {
 
 .container {
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .topics {


### PR DESCRIPTION
## Summary
- select a random topic when loading data
- show a question right away instead of waiting for a click
- center quiz tile using flexbox

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686b756b0e3c832094ed50218a1428ef