### PR TITLE
Add refresh button and persistent category highlight

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,7 @@
 let questions = {};
 let currentAnswer = null;
+let currentTopic = null;
+const topicButtons = {};
 
 async function loadData() {
     const res = await fetch('questions.json');
@@ -10,6 +12,7 @@ async function loadData() {
         btn.className = 'topic';
         btn.textContent = topic;
         btn.addEventListener('click', () => loadQuestion(topic));
+        topicButtons[topic] = btn;
         topicsDiv.appendChild(btn);
     });
 
@@ -35,6 +38,13 @@ function loadQuestion(topic) {
     optionsDiv.innerHTML = '';
     resultDiv.textContent = '';
     currentAnswer = q.answer;
+    if (currentTopic && topicButtons[currentTopic]) {
+        topicButtons[currentTopic].classList.remove('active');
+    }
+    currentTopic = topic;
+    if (topicButtons[currentTopic]) {
+        topicButtons[currentTopic].classList.add('active');
+    }
 
     q.options.forEach((opt, idx) => {
         const div = document.createElement('div');
@@ -56,4 +66,14 @@ function checkAnswer(idx) {
     }
 }
 
-window.addEventListener('DOMContentLoaded', loadData);
+window.addEventListener('DOMContentLoaded', () => {
+    loadData();
+    const refresh = document.getElementById('refresh-btn');
+    if (refresh) {
+        refresh.addEventListener('click', () => {
+            if (currentTopic) {
+                loadQuestion(currentTopic);
+            }
+        });
+    }
+});

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <div class="container">
         <div class="topics" id="topics"></div>
         <div class="quiz-tile" id="quiz">
+            <button id="refresh-btn" class="refresh-btn" title="New Question">&#8635;</button>
             <div class="question" id="question"></div>
             <div class="options" id="options"></div>
             <div class="result" id="result"></div>

--- a/style.css
+++ b/style.css
@@ -38,7 +38,13 @@ body {
     color: #000;
 }
 
+.topic.active {
+    background: #39ff14;
+    color: #000;
+}
+
 .quiz-tile {
+    position: relative;
     background: #1e1e1e;
     padding: 2rem;
     border-radius: 10px;
@@ -70,6 +76,17 @@ body {
 .result {
     margin-top: 1rem;
     font-weight: bold;
+}
+
+.refresh-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: transparent;
+    border: none;
+    color: #39ff14;
+    font-size: 1.2rem;
+    cursor: pointer;
 }
 
 .note {


### PR DESCRIPTION
## Summary
- add a small refresh button to the quiz tile so users can load another question from the same category
- keep the selected category highlighted
- style the refresh button and active topics

## Testing
- `node --check app.js`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_686b76fb50808320b6e1b3583c745473