### PR TITLE
Fix deploy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LLM Quiz Time
 
-![Deploy](https://github.com/llmquiz/llm-quiz-time/actions/workflows/deploy.yml/badge.svg)
+![Deploy](https://github.com/kaustubhdhole/llm-quiz-time/actions/workflows/deploy.yml/badge.svg)
 ![License](https://img.shields.io/github/license/llmquiz/llm-quiz-time)
 ![Issues](https://img.shields.io/github/issues/llmquiz/llm-quiz-time)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Fkaustubhdhole.github.io%2Fllm-quiz-time%2F)](https://kaustubhdhole.github.io/llm-quiz-time/)


### PR DESCRIPTION
## Summary
- fix the deploy badge URL in README

## Testing
- `python add_hints.py`

------
https://chatgpt.com/codex/tasks/task_e_686b7cd770b88320ab8f5cebe4427f3b