### PR TITLE
Fix refresh button keeps current category

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,7 +75,11 @@ window.addEventListener('DOMContentLoaded', () => {
     const refresh = document.getElementById('refresh-btn');
     if (refresh) {
         refresh.addEventListener('click', () => {
-            loadRandomQuestion();
+            if (currentTopic) {
+                loadQuestion(currentTopic);
+            } else {
+                loadRandomQuestion();
+            }
         });
     }
 });


### PR DESCRIPTION
## Summary
- keep current topic when the refresh button is clicked

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b80392b748320b6e1fd8a940514b3