### PR TITLE
Add day/night toggle feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Topics now include planning, reasoning, long-context, data valuation, learning r
 ## Usage
 Open `index.html` in your browser. The page fetches questions from
 `questions.json` and displays one randomly.
+Use the moon button in the top-left corner to toggle between day and night modes.
 
 ## Deployment
 The repository includes a GitHub Actions workflow that publishes the contents of

--- a/app.js
+++ b/app.js
@@ -5,6 +5,15 @@ let currentElaboration = '';
 let currentTopic = null;
 const topicButtons = {};
 
+function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+    const toggle = document.getElementById('theme-toggle');
+    if (toggle) {
+        toggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+    }
+}
+
 async function loadData() {
     const res = await fetch('questions.json');
     questions = await res.json();
@@ -62,7 +71,7 @@ function loadQuestion(topic) {
 function checkAnswer(idx) {
     const resultDiv = document.getElementById('result');
     if (idx === currentAnswer) {
-        resultDiv.style.color = '#39ff14';
+        resultDiv.style.color = 'var(--accent-color)';
         resultDiv.innerHTML = `&#10004; Correct! ${currentElaboration}`;
     } else {
         resultDiv.style.color = 'red';
@@ -72,6 +81,15 @@ function checkAnswer(idx) {
 
 window.addEventListener('DOMContentLoaded', () => {
     loadData();
+    const storedTheme = localStorage.getItem('theme') || 'dark';
+    applyTheme(storedTheme);
+    const themeToggle = document.getElementById('theme-toggle');
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            const current = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+            applyTheme(current);
+        });
+    }
     const refresh = document.getElementById('refresh-btn');
     if (refresh) {
         refresh.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <div class="container">
+        <button id="theme-toggle" class="theme-toggle" title="Toggle Day/Night">🌙</button>
         <pre class="ascii-art">
 -+-+-+ +-+-+-+-+ +-+-+-+-+
 L L M   Q u i z   T i m e 

--- a/style.css
+++ b/style.css
@@ -1,9 +1,29 @@
+:root {
+    --bg-color: #0d0d0d;
+    --text-color: #f1f1f1;
+    --tile-bg: #1e1e1e;
+    --button-bg: #2e2e2e;
+    --accent-color: #39ff14;
+    --accent-text-color: #000;
+    --note-text-color: #bdbdbd;
+}
+
+[data-theme="light"] {
+    --bg-color: #ffffff;
+    --text-color: #000000;
+    --tile-bg: #f0f0f0;
+    --button-bg: #e0e0e0;
+    --accent-color: #007bff;
+    --accent-text-color: #ffffff;
+    --note-text-color: #333333;
+}
+
 body {
     margin: 0;
     padding: 0;
     font-family: "Courier New", monospace;
-    background: #0d0d0d;
-    color: #f1f1f1;
+    background: var(--bg-color);
+    color: var(--text-color);
     height: 100vh;
     display: flex;
     justify-content: center;
@@ -16,6 +36,7 @@ body {
     flex-direction: column;
     align-items: center;
     gap: 1.5rem;
+    position: relative;
 }
 
 .topics {
@@ -28,28 +49,28 @@ body {
 .topic {
     margin: 0.25rem;
     padding: 0.5rem 1rem;
-    background: #2e2e2e;
+    background: var(--button-bg);
     border-radius: 5px;
     cursor: pointer;
     transition: background 0.3s;
 }
 
 .topic:hover {
-    background: #39ff14;
-    color: #000;
+    background: var(--accent-color);
+    color: var(--accent-text-color);
 }
 
 .topic.active {
-    background: #39ff14;
-    color: #000;
+    background: var(--accent-color);
+    color: var(--accent-text-color);
 }
 
 .quiz-tile {
     position: relative;
-    background: #1e1e1e;
+    background: var(--tile-bg);
     padding: 2rem;
     border-radius: 10px;
-    box-shadow: 0 0 10px #39ff14;
+    box-shadow: 0 0 10px var(--accent-color);
     max-width: 500px;
     width: 90%;
     margin: 0 auto;
@@ -63,15 +84,15 @@ body {
 .option {
     margin: 0.5rem 0;
     padding: 0.5rem;
-    background: #2e2e2e;
+    background: var(--button-bg);
     border-radius: 5px;
     cursor: pointer;
     transition: background 0.3s;
 }
 
 .option:hover {
-    background: #39ff14;
-    color: #000;
+    background: var(--accent-color);
+    color: var(--accent-text-color);
 }
 
 .result {
@@ -85,10 +106,10 @@ body {
     right: 0.5rem;
     width: 2rem;
     height: 2rem;
-    background: #1e1e1e;
-    border: 1px solid #39ff14;
+    background: var(--tile-bg);
+    border: 1px solid var(--accent-color);
     border-radius: 50%;
-    color: #39ff14;
+    color: var(--accent-color);
     font-size: 1.2rem;
     cursor: pointer;
     display: flex;
@@ -99,18 +120,40 @@ body {
 
 .refresh-btn:hover {
     transform: rotate(90deg);
-    box-shadow: 0 0 5px #39ff14, 0 0 10px #39ff14;
+    box-shadow: 0 0 5px var(--accent-color), 0 0 10px var(--accent-color);
+}
+
+.theme-toggle {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    width: 2rem;
+    height: 2rem;
+    background: var(--tile-bg);
+    border: 1px solid var(--accent-color);
+    border-radius: 50%;
+    color: var(--accent-color);
+    font-size: 1.2rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: box-shadow 0.3s;
+}
+
+.theme-toggle:hover {
+    box-shadow: 0 0 5px var(--accent-color), 0 0 10px var(--accent-color);
 }
 
 .note {
     margin-top: 1rem;
     font-size: 0.8rem;
-    color: #bdbdbd;
+    color: var(--note-text-color);
 }
 
 .ascii-art {
     margin-bottom: 1rem;
-    color: #39ff14;
+    color: var(--accent-color);
     font-family: "Courier New", monospace;
     white-space: pre;
 }


### PR DESCRIPTION
## Summary
- add a theme toggle button
- support light and dark themes with CSS variables
- persist theme preference in localStorage
- document how to toggle themes

## Testing
- `python -m py_compile add_hints.py`

------
https://chatgpt.com/codex/tasks/task_e_686c6f4ba59c83209529685d8fef9bd5