### PR TITLE
Add category scoring and unique question flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@ L L M   Q u i z   T i m e
             <div class="options" id="options"></div>
             <div class="result" id="result"></div>
         </div>
+        <div class="scoreboard" id="scoreboard" style="display:none;"></div>
         <p class="note">Note that Questions and Answers are AI generated, and may contain hallucinations. </p>
     </div>
 <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -158,3 +158,20 @@ body {
     font-family: "Courier New", monospace;
     white-space: pre;
 }
+
+.scoreboard {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: var(--tile-bg);
+    border: 1px solid var(--accent-color);
+    border-radius: 8px;
+    padding: 1rem;
+    color: var(--accent-color);
+    max-width: 200px;
+    font-size: 0.9rem;
+}
+
+.scoreboard h3 {
+    margin: 0 0 0.5rem 0;
+}


### PR DESCRIPTION
## Summary
- track used questions and per-category score
- auto-switch topics once exhausted
- show performance results in a new scoreboard

## Testing
- `jq empty questions.json`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_686c73ca9a448320b97abfbb98281e34