### PR TITLE
Fancier dashboard with progress bars

### DIFF
--- a/app.js
+++ b/app.js
@@ -134,7 +134,8 @@ function updateScoreboard() {
     Object.keys(score).forEach(topic => {
         const s = score[topic];
         const pct = s.total ? Math.round((s.correct / s.total) * 100) : 0;
-        html += `<li>${topic}: ${pct}% (${s.correct}/${s.total})</li>`;
+        html += `<li>${topic}: ${pct}% (${s.correct}/${s.total})` +
+            `<div class="scorebar"><div class="scorebar-fill" style="width:${pct}%"></div></div></li>`;
     });
     html += '</ul>';
     board.innerHTML = html;

--- a/style.css
+++ b/style.css
@@ -44,6 +44,7 @@ body {
     flex-wrap: wrap;
     justify-content: center;
     margin-bottom: 1rem;
+    max-width: calc(100% - 240px);
 }
 
 .topic {
@@ -168,10 +169,37 @@ body {
     border-radius: 8px;
     padding: 1rem;
     color: var(--accent-color);
-    max-width: 200px;
+    max-width: 220px;
     font-size: 0.9rem;
 }
 
+.scoreboard ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.scoreboard li {
+    margin-bottom: 0.75rem;
+}
+
+.scoreboard li:last-child {
+    margin-bottom: 0;
+}
+
+.scorebar {
+    width: 100%;
+    height: 0.5rem;
+    background: var(--button-bg);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-top: 0.25rem;
+}
+
+.scorebar-fill {
+    height: 100%;
+    background: var(--accent-color);
+}
 .scoreboard h3 {
     margin: 0 0 0.5rem 0;
 }


### PR DESCRIPTION
## Summary
- make topics container narrower so it doesn't collide with the scoreboard
- add bar-style progress visualization to the scoreboard

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_686c789deaa0832089bb7bd759d8c389