### PR TITLE
Display scoreboard with default 0% performance

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,10 +28,15 @@ async function loadData() {
         btn.addEventListener('click', () => loadQuestion(topic));
         topicButtons[topic] = btn;
         topicsDiv.appendChild(btn);
+
+        // initialize score tracking for each topic
+        score[topic] = { correct: 0, total: 0 };
     });
 
     // Display a random question on initial load
     loadRandomQuestion();
+    // Show initial scoreboard with 0% for all topics
+    updateScoreboard();
 }
 
 function loadRandomQuestion() {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ L L M   Q u i z   T i m e
             <div class="options" id="options"></div>
             <div class="result" id="result"></div>
         </div>
-        <div class="scoreboard" id="scoreboard" style="display:none;"></div>
+        <div class="scoreboard" id="scoreboard"></div>
         <p class="note">Note that Questions and Answers are AI generated, and may contain hallucinations. </p>
     </div>
 <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- show scoreboard on page load
- initialize score entries for each topic and update scoreboard right away

## Testing
- `node -v`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c8177bafc83209b825730e3fc689c