### PR TITLE
Improve scoreboard UX

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 let questions = {};
 let currentAnswer = null;
-let currentHint = '';
-let currentElaboration = '';
+let currentHint = "";
+let currentElaboration = "";
 let currentTopic = null;
 const topicButtons = {};
 const usedQuestions = {};
@@ -9,162 +9,187 @@ const score = {};
 const completedTopics = new Set();
 
 function applyTheme(theme) {
-    document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
-    const toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-        toggle.textContent = theme === 'dark' ? '☀️' : '🌙';
-    }
+  document.documentElement.setAttribute("data-theme", theme);
+  localStorage.setItem("theme", theme);
+  const toggle = document.getElementById("theme-toggle");
+  if (toggle) {
+    toggle.textContent = theme === "dark" ? "☀️" : "🌙";
+  }
 }
 
 async function loadData() {
-    const res = await fetch('questions.json');
-    questions = await res.json();
-    const topicsDiv = document.getElementById('topics');
-    Object.keys(questions).forEach(topic => {
-        const btn = document.createElement('div');
-        btn.className = 'topic';
-        btn.textContent = topic;
-        btn.addEventListener('click', () => loadQuestion(topic));
-        topicButtons[topic] = btn;
-        topicsDiv.appendChild(btn);
+  const res = await fetch("questions.json");
+  questions = await res.json();
+  const topicsDiv = document.getElementById("topics");
+  Object.keys(questions).forEach((topic) => {
+    const btn = document.createElement("div");
+    btn.className = "topic";
+    btn.textContent = topic;
+    btn.addEventListener("click", () => loadQuestion(topic));
+    topicButtons[topic] = btn;
+    topicsDiv.appendChild(btn);
 
-        // initialize score tracking for each topic
-        score[topic] = { correct: 0, total: 0 };
-    });
+    // initialize score tracking for each topic
+    score[topic] = { correct: 0, total: 0 };
+  });
 
-    // Display a random question on initial load
-    loadRandomQuestion();
-    // Show initial scoreboard with 0% for all topics
-    updateScoreboard();
+  // Display a random question on initial load
+  loadRandomQuestion();
+  // Show initial scoreboard with 0% for all topics
+  updateScoreboard();
 }
 
 function loadRandomQuestion() {
-    const topics = Object.keys(questions).filter(t => !completedTopics.has(t));
-    if (topics.length === 0) return;
-    const randomTopic = topics[Math.floor(Math.random() * topics.length)];
-    loadQuestion(randomTopic);
+  const topics = Object.keys(questions).filter((t) => !completedTopics.has(t));
+  if (topics.length === 0) return;
+  const randomTopic = topics[Math.floor(Math.random() * topics.length)];
+  loadQuestion(randomTopic);
 }
 
 function loadQuestion(topic) {
-    if (!usedQuestions[topic]) usedQuestions[topic] = new Set();
-    const arr = questions[topic];
-    const used = usedQuestions[topic];
+  if (!usedQuestions[topic]) usedQuestions[topic] = new Set();
+  const arr = questions[topic];
+  const used = usedQuestions[topic];
 
-    if (used.size >= arr.length) {
-        completedTopics.add(topic);
-        if (topicButtons[topic]) {
-            topicButtons[topic].style.display = 'none';
-        }
-        const remaining = Object.keys(questions).filter(t => !completedTopics.has(t));
-        if (remaining.length === 0) {
-            const qDiv = document.getElementById('question');
-            const optionsDiv = document.getElementById('options');
-            qDiv.textContent = 'Quiz complete!';
-            optionsDiv.innerHTML = '';
-            currentTopic = null;
-            return;
-        }
-        const next = remaining[Math.floor(Math.random() * remaining.length)];
-        loadQuestion(next);
-        return;
+  if (used.size >= arr.length) {
+    completedTopics.add(topic);
+    if (topicButtons[topic]) {
+      topicButtons[topic].style.display = "none";
     }
-
-    const unused = arr.map((_, i) => i).filter(i => !used.has(i));
-    const qIndex = unused[Math.floor(Math.random() * unused.length)];
-    used.add(qIndex);
-    const q = arr[qIndex];
-    const questionDiv = document.getElementById('question');
-    const optionsDiv = document.getElementById('options');
-    const resultDiv = document.getElementById('result');
-
-    questionDiv.textContent = q.question;
-    optionsDiv.innerHTML = '';
-    resultDiv.textContent = '';
-    currentAnswer = q.answer;
-    currentHint = q.hint || '';
-    currentElaboration = q.elaboration || '';
-    if (currentTopic && topicButtons[currentTopic]) {
-        topicButtons[currentTopic].classList.remove('active');
+    const remaining = Object.keys(questions).filter(
+      (t) => !completedTopics.has(t),
+    );
+    if (remaining.length === 0) {
+      const qDiv = document.getElementById("question");
+      const optionsDiv = document.getElementById("options");
+      qDiv.textContent = "Quiz complete!";
+      optionsDiv.innerHTML = "";
+      currentTopic = null;
+      return;
     }
-    currentTopic = topic;
-    if (topicButtons[currentTopic]) {
-        topicButtons[currentTopic].classList.add('active');
-    }
+    const next = remaining[Math.floor(Math.random() * remaining.length)];
+    loadQuestion(next);
+    return;
+  }
 
-    q.options.forEach((opt, idx) => {
-        const div = document.createElement('div');
-        div.className = 'option';
-        div.textContent = opt;
-        div.addEventListener('click', () => checkAnswer(idx));
-        optionsDiv.appendChild(div);
-    });
+  const unused = arr.map((_, i) => i).filter((i) => !used.has(i));
+  const qIndex = unused[Math.floor(Math.random() * unused.length)];
+  used.add(qIndex);
+  const q = arr[qIndex];
+  const questionDiv = document.getElementById("question");
+  const optionsDiv = document.getElementById("options");
+  const resultDiv = document.getElementById("result");
+
+  questionDiv.textContent = q.question;
+  optionsDiv.innerHTML = "";
+  resultDiv.textContent = "";
+  currentAnswer = q.answer;
+  currentHint = q.hint || "";
+  currentElaboration = q.elaboration || "";
+  if (currentTopic && topicButtons[currentTopic]) {
+    topicButtons[currentTopic].classList.remove("active");
+  }
+  currentTopic = topic;
+  if (topicButtons[currentTopic]) {
+    topicButtons[currentTopic].classList.add("active");
+  }
+
+  q.options.forEach((opt, idx) => {
+    const div = document.createElement("div");
+    div.className = "option";
+    div.textContent = opt;
+    div.addEventListener("click", () => checkAnswer(idx));
+    optionsDiv.appendChild(div);
+  });
 }
 
 function checkAnswer(idx) {
-    const resultDiv = document.getElementById('result');
-    if (!score[currentTopic]) {
-        score[currentTopic] = { correct: 0, total: 0 };
-    }
-    score[currentTopic].total++;
-    if (idx === currentAnswer) {
-        score[currentTopic].correct++;
-        resultDiv.style.color = 'var(--accent-color)';
-        resultDiv.innerHTML = `&#10004; Correct! ${currentElaboration}`;
-    } else {
-        resultDiv.style.color = 'red';
-        resultDiv.innerHTML = `&#10008; Not quite, try again! ${currentHint}`;
-    }
+  const resultDiv = document.getElementById("result");
+  if (!score[currentTopic]) {
+    score[currentTopic] = { correct: 0, total: 0 };
+  }
+  score[currentTopic].total++;
+  if (idx === currentAnswer) {
+    score[currentTopic].correct++;
+    resultDiv.style.color = "var(--accent-color)";
+    resultDiv.innerHTML = `&#10004; Correct! ${currentElaboration}`;
+  } else {
+    resultDiv.style.color = "red";
+    resultDiv.innerHTML = `&#10008; Not quite, try again! ${currentHint}`;
+  }
 
-    const arr = questions[currentTopic];
-    if (usedQuestions[currentTopic].size >= arr.length) {
-        completedTopics.add(currentTopic);
-        if (topicButtons[currentTopic]) {
-            topicButtons[currentTopic].style.display = 'none';
-        }
-        updateScoreboard();
-        const remaining = Object.keys(questions).filter(t => !completedTopics.has(t));
-        if (remaining.length > 0) {
-            const next = remaining[Math.floor(Math.random() * remaining.length)];
-            setTimeout(() => loadQuestion(next), 1000);
-        }
+  const arr = questions[currentTopic];
+  if (usedQuestions[currentTopic].size >= arr.length) {
+    completedTopics.add(currentTopic);
+    if (topicButtons[currentTopic]) {
+      topicButtons[currentTopic].style.display = "none";
     }
+    updateScoreboard();
+    const remaining = Object.keys(questions).filter(
+      (t) => !completedTopics.has(t),
+    );
+    if (remaining.length > 0) {
+      const next = remaining[Math.floor(Math.random() * remaining.length)];
+      setTimeout(() => loadQuestion(next), 1000);
+    }
+  }
 }
 
 function updateScoreboard() {
-    const board = document.getElementById('scoreboard');
-    if (!board) return;
-    board.style.display = 'block';
-    let html = '<h3>Performance</h3><ul>';
-    Object.keys(score).forEach(topic => {
-        const s = score[topic];
-        const pct = s.total ? Math.round((s.correct / s.total) * 100) : 0;
-        html += `<li>${topic}: ${pct}% (${s.correct}/${s.total})` +
-            `<div class="scorebar"><div class="scorebar-fill" style="width:${pct}%"></div></div></li>`;
-    });
-    html += '</ul>';
-    board.innerHTML = html;
+  const board = document.getElementById("scoreboard");
+  if (!board) return;
+  board.style.display = "block";
+  let html = "<h3>Performance</h3><ul>";
+  Object.keys(score).forEach((topic) => {
+    const s = score[topic];
+    const pct = s.total ? Math.round((s.correct / s.total) * 100) : 0;
+    html +=
+      `<li>${topic}: ${pct}% (${s.correct}/${s.total})` +
+      `<div class="scorebar"><div class="scorebar-fill" style="width:${pct}%"></div></div></li>`;
+  });
+  html += "</ul>";
+  board.innerHTML = html;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
-    loadData();
-    const storedTheme = localStorage.getItem('theme') || 'dark';
-    applyTheme(storedTheme);
-    const themeToggle = document.getElementById('theme-toggle');
-    if (themeToggle) {
-        themeToggle.addEventListener('click', () => {
-            const current = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
-            applyTheme(current);
+window.addEventListener("DOMContentLoaded", () => {
+  loadData();
+  const storedTheme = localStorage.getItem("theme") || "dark";
+  applyTheme(storedTheme);
+  const themeToggle = document.getElementById("theme-toggle");
+  if (themeToggle) {
+    themeToggle.addEventListener("click", () => {
+      const current =
+        document.documentElement.getAttribute("data-theme") === "light"
+          ? "dark"
+          : "light";
+      applyTheme(current);
+    });
+  }
+  const refresh = document.getElementById("refresh-btn");
+  if (refresh) {
+    refresh.addEventListener("click", () => {
+      if (currentTopic) {
+        loadQuestion(currentTopic);
+      } else {
+        loadRandomQuestion();
+      }
+    });
+  }
+
+  const scoreboard = document.getElementById("scoreboard");
+  if (scoreboard) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            scoreboard.classList.add("expanded");
+          } else {
+            scoreboard.classList.remove("expanded");
+          }
         });
-    }
-    const refresh = document.getElementById('refresh-btn');
-    if (refresh) {
-        refresh.addEventListener('click', () => {
-            if (currentTopic) {
-                loadQuestion(currentTopic);
-            } else {
-                loadRandomQuestion();
-            }
-        });
-    }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(scoreboard);
+  }
 });

--- a/index.html
+++ b/index.html
@@ -1,31 +1,39 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LLM Quiz Time</title>
     <!-- Ensure paths resolve when served from a repository subpath -->
-    <base href="/llm-quiz-time/">
-    <link rel="stylesheet" href="style.css">
-</head>
-<body>
+    <base href="/llm-quiz-time/" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
     <div class="container">
-        <button id="theme-toggle" class="theme-toggle" title="Toggle Day/Night">🌙</button>
-        <pre class="ascii-art">
+      <button id="theme-toggle" class="theme-toggle" title="Toggle Day/Night">
+        🌙
+      </button>
+      <pre class="ascii-art">
 -+-+-+ +-+-+-+-+ +-+-+-+-+
 L L M   Q u i z   T i m e 
 -+-+-+ +-+-+-+-+ +-+-+-+-+
-        </pre>
-        <div class="topics" id="topics"></div>
-        <div class="quiz-tile" id="quiz">
-            <button id="refresh-btn" class="refresh-btn" title="New Question">&#8635;</button>
-            <div class="question" id="question"></div>
-            <div class="options" id="options"></div>
-            <div class="result" id="result"></div>
-        </div>
-        <div class="scoreboard" id="scoreboard"></div>
-        <p class="note">Note that Questions and Answers are AI generated, and may contain hallucinations. </p>
+        </pre
+      >
+      <div class="topics" id="topics"></div>
+      <div class="quiz-tile" id="quiz">
+        <button id="refresh-btn" class="refresh-btn" title="New Question">
+          &#8635;
+        </button>
+        <div class="question" id="question"></div>
+        <div class="options" id="options"></div>
+        <div class="result" id="result"></div>
+      </div>
+      <p class="note">
+        Note that Questions and Answers are AI generated, and may contain
+        hallucinations.
+      </p>
+      <div class="scoreboard" id="scoreboard"></div>
     </div>
-<script src="app.js"></script>
-</body>
+    <script src="app.js"></script>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,205 +1,222 @@
 :root {
-    --bg-color: #0d0d0d;
-    --text-color: #f1f1f1;
-    --tile-bg: #1e1e1e;
-    --button-bg: #2e2e2e;
-    --accent-color: #39ff14;
-    --accent-text-color: #000;
-    --note-text-color: #bdbdbd;
+  --bg-color: #0d0d0d;
+  --text-color: #f1f1f1;
+  --tile-bg: #1e1e1e;
+  --button-bg: #2e2e2e;
+  --accent-color: #39ff14;
+  --accent-text-color: #000;
+  --note-text-color: #bdbdbd;
 }
 
 [data-theme="light"] {
-    --bg-color: #ffffff;
-    --text-color: #000000;
-    --tile-bg: #f0f0f0;
-    --button-bg: #e0e0e0;
-    --accent-color: #007bff;
-    --accent-text-color: #ffffff;
-    --note-text-color: #333333;
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --tile-bg: #f0f0f0;
+  --button-bg: #e0e0e0;
+  --accent-color: #007bff;
+  --accent-text-color: #ffffff;
+  --note-text-color: #333333;
 }
 
 body {
-    margin: 0;
-    padding: 0;
-    font-family: "Courier New", monospace;
-    background: var(--bg-color);
-    color: var(--text-color);
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  margin: 0;
+  padding: 0;
+  font-family: "Courier New", monospace;
+  background: var(--bg-color);
+  color: var(--text-color);
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .container {
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1.5rem;
-    position: relative;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  position: relative;
 }
 
 .topics {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    margin-bottom: 1rem;
-    max-width: calc(100% - 240px);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 1rem;
+  max-width: calc(100% - 240px);
 }
 
 .topic {
-    margin: 0.25rem;
-    padding: 0.5rem 1rem;
-    background: var(--button-bg);
-    border-radius: 5px;
-    cursor: pointer;
-    transition: background 0.3s;
+  margin: 0.25rem;
+  padding: 0.5rem 1rem;
+  background: var(--button-bg);
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.3s;
 }
 
 .topic:hover {
-    background: var(--accent-color);
-    color: var(--accent-text-color);
+  background: var(--accent-color);
+  color: var(--accent-text-color);
 }
 
 .topic.active {
-    background: var(--accent-color);
-    color: var(--accent-text-color);
+  background: var(--accent-color);
+  color: var(--accent-text-color);
 }
 
 .quiz-tile {
-    position: relative;
-    background: var(--tile-bg);
-    padding: 2rem;
-    border-radius: 10px;
-    box-shadow: 0 0 10px var(--accent-color);
-    max-width: 500px;
-    width: 90%;
-    margin: 0 auto;
+  position: relative;
+  background: var(--tile-bg);
+  padding: 2rem;
+  border-radius: 10px;
+  box-shadow: 0 0 10px var(--accent-color);
+  max-width: 500px;
+  width: 90%;
+  margin: 0 auto;
 }
 
 .question {
-    font-size: 1.25rem;
-    margin-bottom: 1rem;
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
 }
 
 .option {
-    margin: 0.5rem 0;
-    padding: 0.5rem;
-    background: var(--button-bg);
-    border-radius: 5px;
-    cursor: pointer;
-    transition: background 0.3s;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  background: var(--button-bg);
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.3s;
 }
 
 .option:hover {
-    background: var(--accent-color);
-    color: var(--accent-text-color);
+  background: var(--accent-color);
+  color: var(--accent-text-color);
 }
 
 .result {
-    margin-top: 1rem;
-    font-weight: bold;
+  margin-top: 1rem;
+  font-weight: bold;
 }
 
 .refresh-btn {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    width: 2rem;
-    height: 2rem;
-    background: var(--tile-bg);
-    border: 1px solid var(--accent-color);
-    border-radius: 50%;
-    color: var(--accent-color);
-    font-size: 1.2rem;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: transform 0.3s, box-shadow 0.3s;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  background: var(--tile-bg);
+  border: 1px solid var(--accent-color);
+  border-radius: 50%;
+  color: var(--accent-color);
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    transform 0.3s,
+    box-shadow 0.3s;
 }
 
 .refresh-btn:hover {
-    transform: rotate(90deg);
-    box-shadow: 0 0 5px var(--accent-color), 0 0 10px var(--accent-color);
+  transform: rotate(90deg);
+  box-shadow:
+    0 0 5px var(--accent-color),
+    0 0 10px var(--accent-color);
 }
 
 .theme-toggle {
-    position: absolute;
-    top: 0.5rem;
-    left: 25%;
-    transform: translateX(-25%);
-    width: 2rem;
-    height: 2rem;
-    background: var(--tile-bg);
-    border: 1px solid var(--accent-color);
-    border-radius: 50%;
-    color: var(--accent-color);
-    font-size: 1.2rem;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: box-shadow 0.3s;
+  position: absolute;
+  top: 0.5rem;
+  left: 25%;
+  transform: translateX(-25%);
+  width: 2rem;
+  height: 2rem;
+  background: var(--tile-bg);
+  border: 1px solid var(--accent-color);
+  border-radius: 50%;
+  color: var(--accent-color);
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: box-shadow 0.3s;
 }
 
 .theme-toggle:hover {
-    box-shadow: 0 0 5px var(--accent-color), 0 0 10px var(--accent-color);
+  box-shadow:
+    0 0 5px var(--accent-color),
+    0 0 10px var(--accent-color);
 }
 
 .note {
-    margin-top: 1rem;
-    font-size: 0.8rem;
-    color: var(--note-text-color);
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  color: var(--note-text-color);
 }
 
 .ascii-art {
-    margin-bottom: 1rem;
-    color: var(--accent-color);
-    font-family: "Courier New", monospace;
-    white-space: pre;
+  margin-bottom: 1rem;
+  color: var(--accent-color);
+  font-family: "Courier New", monospace;
+  white-space: pre;
 }
 
 .scoreboard {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    background: var(--tile-bg);
-    border: 1px solid var(--accent-color);
-    border-radius: 8px;
-    padding: 1rem;
-    color: var(--accent-color);
-    max-width: 220px;
-    font-size: 0.9rem;
+  position: relative;
+  background: var(--tile-bg);
+  border: 1px solid var(--accent-color);
+  border-radius: 8px;
+  padding: 1rem;
+  color: var(--accent-color);
+  max-width: 220px;
+  font-size: 0.9rem;
+  margin-top: 2rem;
+  max-height: 2rem;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+}
+
+.scoreboard.expanded {
+  max-height: 100vh;
 }
 
 .scoreboard ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: none;
+}
+
+.scoreboard.expanded ul {
+  display: block;
 }
 
 .scoreboard li {
-    margin-bottom: 0.75rem;
+  margin-bottom: 0.75rem;
 }
 
 .scoreboard li:last-child {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .scorebar {
-    width: 100%;
-    height: 0.5rem;
-    background: var(--button-bg);
-    border-radius: 4px;
-    overflow: hidden;
-    margin-top: 0.25rem;
+  width: 100%;
+  height: 0.5rem;
+  background: var(--button-bg);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-top: 0.25rem;
 }
 
 .scorebar-fill {
-    height: 100%;
-    background: var(--accent-color);
+  height: 100%;
+  background: var(--accent-color);
 }
 .scoreboard h3 {
-    margin: 0 0 0.5rem 0;
+  margin: 0 0 0.5rem 0;
 }


### PR DESCRIPTION
## Summary
- keep scoreboard collapsed by default
- expand the scoreboard when the user scrolls to it
- move performance section below the note
- format files with Prettier

## Testing
- `python -m py_compile add_hints.py`


------
https://chatgpt.com/codex/tasks/task_e_686c9aba4f688320bf082f4a02277426