### PR TITLE
Add toggle for performance metrics

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const topicButtons = {};
 const usedQuestions = {};
 const score = {};
 const completedTopics = new Set();
+let scoreboardVisible = true;
 
 function applyTheme(theme) {
     document.documentElement.setAttribute('data-theme', theme);
@@ -134,7 +135,7 @@ function checkAnswer(idx) {
 function updateScoreboard() {
     const board = document.getElementById('scoreboard');
     if (!board) return;
-    board.style.display = 'block';
+    board.style.display = scoreboardVisible ? 'block' : 'none';
     let html = '<h3>Performance</h3><ul>';
     Object.keys(score).forEach(topic => {
         const s = score[topic];
@@ -165,6 +166,14 @@ window.addEventListener('DOMContentLoaded', () => {
             } else {
                 loadRandomQuestion();
             }
+        });
+    }
+
+    const boardToggle = document.getElementById('scoreboard-toggle');
+    if (boardToggle) {
+        boardToggle.addEventListener('click', () => {
+            scoreboardVisible = !scoreboardVisible;
+            updateScoreboard();
         });
     }
 });

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@ L L M   Q u i z   T i m e
             <div class="result" id="result"></div>
         </div>
         <div class="scoreboard" id="scoreboard"></div>
+        <button id="scoreboard-toggle" class="scoreboard-toggle" title="Toggle Performance">📊</button>
         <p class="note">Note that Questions and Answers are AI generated, and may contain hallucinations. </p>
     </div>
 <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -203,3 +203,25 @@ body {
 .scoreboard h3 {
     margin: 0 0 0.5rem 0;
 }
+
+.scoreboard-toggle {
+    position: absolute;
+    bottom: 1rem;
+    right: 1rem;
+    width: 2rem;
+    height: 2rem;
+    background: var(--tile-bg);
+    border: 1px solid var(--accent-color);
+    border-radius: 50%;
+    color: var(--accent-color);
+    font-size: 1.2rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: box-shadow 0.3s;
+}
+
+.scoreboard-toggle:hover {
+    box-shadow: 0 0 5px var(--accent-color), 0 0 10px var(--accent-color);
+}


### PR DESCRIPTION
## Summary
- add scoreboard toggle button in `index.html`
- style the button in `style.css`
- implement `scoreboardVisible` flag in `app.js` with a click handler

## Testing
- `node -c app.js`
- `node -e "console.log('Node working')"`


------
https://chatgpt.com/codex/tasks/task_e_686cb07a207883208a7cdebb85dc5b16