### PR TITLE
Hide scoreboard by default

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const topicButtons = {};
 const usedQuestions = {};
 const score = {};
 const completedTopics = new Set();
-let scoreboardVisible = true;
+let scoreboardVisible = false;
 
 function applyTheme(theme) {
     document.documentElement.setAttribute('data-theme', theme);

--- a/style.css
+++ b/style.css
@@ -171,6 +171,7 @@ body {
     color: var(--accent-color);
     max-width: 220px;
     font-size: 0.9rem;
+    display: none;
 }
 
 .scoreboard ul {


### PR DESCRIPTION
## Summary
- hide scoreboard widget on initial load

## Testing
- `python3 -m py_compile add_hints.py`


------
https://chatgpt.com/codex/tasks/task_e_686dd43d943c8320b338bc9f1d1979d5