### PR TITLE
Add multi-tab quiz interface with lessons gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,24 +9,47 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container">
-        <button id="theme-toggle" class="theme-toggle" title="Toggle Day/Night">🌙</button>
-        <pre class="ascii-art">
--+-+-+ +-+-+-+-+ +-+-+-+-+
-L L M   Q u i z   T i m e 
--+-+-+ +-+-+-+-+ +-+-+-+-+
-        </pre>
-        <div class="topics" id="topics"></div>
-        <div class="quiz-tile" id="quiz">
-            <button id="refresh-btn" class="refresh-btn" title="New Question">&#8635;</button>
-            <div class="question" id="question"></div>
-            <div class="options" id="options"></div>
-            <div class="result" id="result"></div>
-        </div>
-        <div class="scoreboard" id="scoreboard"></div>
-        <button id="scoreboard-toggle" class="scoreboard-toggle" title="Toggle Performance">📊</button>
-        <p class="note">Note that Questions and Answers are AI generated, and may contain hallucinations. </p>
+    <button id="theme-toggle" class="theme-toggle" title="Toggle Day/Night">🌙</button>
+    <div class="tabs">
+        <div class="tab-link active" data-tab="quiz-tab">LLM Quiz Time</div>
+        <div class="tab-link" data-tab="science-tab">The Science Behind LLM Breakthroughs</div>
     </div>
-<script src="app.js"></script>
+    <div id="quiz-tab" class="tab-content active">
+        <div class="container">
+            <pre class="ascii-art">
+-+-+-+ +-+-+-+-+ +-+-+-+-+
+L L M   Q u i z   T i m e
+-+-+-+ +-+-+-+-+ +-+-+-+-+
+            </pre>
+            <div class="topics" id="topics"></div>
+            <div class="quiz-tile" id="quiz">
+                <button id="refresh-btn" class="refresh-btn" title="New Question">&#8635;</button>
+                <div class="question" id="question"></div>
+                <div class="options" id="options"></div>
+                <div class="result" id="result"></div>
+            </div>
+            <div class="scoreboard" id="scoreboard"></div>
+            <button id="scoreboard-toggle" class="scoreboard-toggle" title="Toggle Performance">📊</button>
+            <p class="note">Note that Questions and Answers are AI generated, and may contain hallucinations. </p>
+        </div>
+    </div>
+    <div id="science-tab" class="tab-content">
+        <div class="lessons">
+            <div class="lesson">
+                <div class="lesson-header" data-lesson="tokenizers">Do you know your tokenizers well?</div>
+                <div class="lesson-content gallery" id="tokenizers"></div>
+            </div>
+            <div class="lesson">
+                <div class="lesson-header" data-lesson="pytorch_resource_accounting">Let's hold you accountable for Pytorch Resource Accounting</div>
+                <div class="lesson-content gallery" id="pytorch_resource_accounting"></div>
+            </div>
+            <div class="lesson">
+                <div class="lesson-header" data-lesson="hyperparameters">Let's see what are your parameters on Hyperparameters!</div>
+                <div class="lesson-content gallery" id="hyperparameters"></div>
+            </div>
+        </div>
+        <p class="note">Note that Questions and Answers are AI generated, and may contain hallucinations.</p>
+    </div>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/lessons/hyperparameters.json
+++ b/lessons/hyperparameters.json
@@ -1,0 +1,72 @@
+[
+    {
+        "question": "Which hyperparameter controls the strength of weight decay in L2 regularization?",
+        "options": ["Batch size", "Weight decay coefficient", "Dropout rate", "Gradient clip threshold"],
+        "answer": 1,
+        "hint": "It's sometimes called the lambda parameter in optimization.",
+        "elaboration": "The weight decay coefficient scales the L2 penalty added to the loss, encouraging smaller parameter values." 
+    },
+    {
+        "question": "What aspect of training is most directly affected by batch size?",
+        "options": ["Model depth", "Gradient noise and memory usage", "Attention head count", "Vocabulary size"],
+        "answer": 1,
+        "hint": "Larger batches reduce variance but need more GPU RAM.",
+        "elaboration": "Batch size sets how many examples are processed before an optimizer step, influencing gradient stability and required memory." 
+    },
+    {
+        "question": "Increasing the number of attention heads mainly aims to",
+        "options": ["Speed up convolution", "Capture diverse relationships", "Reduce vocabulary", "Store more activations"],
+        "answer": 1,
+        "hint": "More heads let the model attend to different subspaces.",
+        "elaboration": "Multi-head attention splits queries into multiple projections so each head can learn unique patterns between tokens." 
+    },
+    {
+        "question": "Doubling the learning rate without other changes can often lead to",
+        "options": ["Underfitting", "Exploding loss and divergence", "Instant convergence", "Exact same behavior"],
+        "answer": 1,
+        "hint": "Too big steps can overshoot minima.",
+        "elaboration": "A larger learning rate might cause training to diverge as updates skip over the optimum or oscillate wildly." 
+    },
+    {
+        "question": "Gradient clipping is used to",
+        "options": ["Zero out small gradients", "Prevent extremely large updates", "Increase batch size", "Change weight decay"],
+        "answer": 1,
+        "hint": "It enforces a maximum norm or value on gradients.",
+        "elaboration": "Clipping limits gradient magnitudes, which helps stabilize training when rare spikes occur, especially in recurrent networks." 
+    },
+    {
+        "question": "A higher dropout rate is typically employed to",
+        "options": ["Speed up inference", "Provide stronger regularization", "Increase model width", "Decrease sequence length"],
+        "answer": 1,
+        "hint": "It randomly disables more neurons.",
+        "elaboration": "Dropout randomly masks activations during training; a higher rate forces the model to rely less on any single feature." 
+    },
+    {
+        "question": "Warmup steps for the learning rate schedule are used to",
+        "options": ["Randomize token order", "Gradually ramp the learning rate", "Shrink the model", "Freeze embeddings"],
+        "answer": 1,
+        "hint": "Helps avoid instability in the first iterations.",
+        "elaboration": "A small learning rate at the beginning allows the optimizer to start in a stable manner before reaching the target rate." 
+    },
+    {
+        "question": "Label smoothing modifies the target distribution by",
+        "options": ["Adding noise to inputs", "Assigning some probability to wrong classes", "Increasing batch normalization", "Scaling gradients"],
+        "answer": 1,
+        "hint": "It avoids putting the entire probability on the correct label.",
+        "elaboration": "Label smoothing replaces one-hot targets with a mixture that reserves a small amount of probability for incorrect classes." 
+    },
+    {
+        "question": "In the Adam optimizer, the beta1 parameter controls",
+        "options": ["Step size", "Decay rate for the first moment estimate", "Number of epochs", "Batch normalization momentum"],
+        "answer": 1,
+        "hint": "It's the exponential moving average of the gradients.",
+        "elaboration": "Beta1 determines how quickly the running average of gradients adapts to new values; lower values react faster." 
+    },
+    {
+        "question": "The step size used by a learning rate scheduler typically refers to",
+        "options": ["How often the learning rate is updated", "Embedding dimension", "Number of attention heads", "Dropout seed"],
+        "answer": 0,
+        "hint": "Some schedulers reduce the rate every fixed number of steps.",
+        "elaboration": "Schedulers like StepLR decrease the learning rate after a set number of optimizer steps or epochs specified by the step size." 
+    }
+]

--- a/lessons/pytorch_resource_accounting.json
+++ b/lessons/pytorch_resource_accounting.json
@@ -1,0 +1,122 @@
+[
+  {
+    "question": "torch.cuda.memory_allocated() reports",
+    "options": [
+      "Total GPU memory",
+      "Memory managed by PyTorch allocator",
+      "CPU RAM usage",
+      "Cache hit rate"
+    ],
+    "answer": 1,
+    "hint": "It doesn't include unused cached memory.",
+    "elaboration": "torch.cuda.memory_allocated() reports memory managed by PyTorch's allocator. It excludes memory held by other libraries or the driver."
+  },
+  {
+    "question": "Which PyTorch feature frees unused GPU memory without leaving the program?",
+    "options": [
+      "torch.save",
+      "torch.cuda.empty_cache",
+      "torch.distributed.barrier",
+      "torch.jit"
+    ],
+    "answer": 1,
+    "hint": "Useful after large tensors are deleted.",
+    "elaboration": "torch.cuda.empty_cache frees unused GPU memory without exiting. This can help avoid out-of-memory errors when tensors are deleted."
+  },
+  {
+    "question": "During mixed precision training, which component consumes extra memory?",
+    "options": [
+      "Grad scaler",
+      "Dataloader",
+      "Optimizer step",
+      "Dropout layer"
+    ],
+    "answer": 0,
+    "hint": "It keeps track of dynamic loss scaling.",
+    "elaboration": "The grad scaler consumes extra memory in mixed precision training. It stores scaling factors to prevent underflow when using float16."
+  },
+  {
+    "question": "torch.no_grad() is helpful during evaluation because",
+    "options": [
+      "It saves GPU memory by not storing gradients",
+      "It speeds up tokenization",
+      "It increases accuracy",
+      "It uses bfloat16"
+    ],
+    "answer": 0,
+    "hint": "Gradients aren't needed for inference.",
+    "elaboration": "torch.no_grad() saves memory by not storing gradients during eval. It also slightly speeds up inference since no backward pass is needed."
+  },
+  {
+    "question": "How can you track peak memory usage over time?",
+    "options": [
+      "torch.cuda.max_memory_allocated",
+      "torch.set_default_dtype",
+      "torch.compile",
+      "torch.utils.data"
+    ],
+    "answer": 0,
+    "hint": "There is an API returning the high watermark.",
+    "elaboration": "torch.cuda.max_memory_allocated tracks peak memory usage. Monitoring this helps diagnose leaks or inefficiencies."
+  },
+  {
+    "question": "What does setting torch.backends.cudnn.benchmark=True do?",
+    "options": [
+      "Reduces memory",
+      "Finds optimal convolution algorithms",
+      "Disables kernels",
+      "Forces deterministic ops"
+    ],
+    "answer": 1,
+    "hint": "It times kernels to find the fastest convolution.",
+    "elaboration": "torch.backends.cudnn.benchmark=True finds optimal convolution algorithms. It times different kernels and caches the fastest choice."
+  },
+  {
+    "question": "In distributed data parallel, gradient buckets are used for",
+    "options": [
+      "Fusing gradients before all-reduce",
+      "Saving model checkpoints",
+      "Computing logits",
+      "Generating text"
+    ],
+    "answer": 0,
+    "hint": "They reduce communication overhead.",
+    "elaboration": "Gradient buckets fuse gradients before all-reduce in DDP. This reduces the number of communication operations."
+  },
+  {
+    "question": "Why might you use torch.cuda.memory_reserved()?",
+    "options": [
+      "To allocate CPU buffers",
+      "To see total memory including cache",
+      "To perform quantization",
+      "To enable dropout"
+    ],
+    "answer": 1,
+    "hint": "Shows memory the allocator reserved from the driver.",
+    "elaboration": "torch.cuda.memory_reserved() shows total reserved memory including cache. It can reveal fragmentation or overhead beyond active tensors."
+  },
+  {
+    "question": "Profiling with torch.autograd.profiler is useful for",
+    "options": [
+      "Counting tokens",
+      "Identifying time and memory hotspots",
+      "Downloading datasets",
+      "Computing scaling laws"
+    ],
+    "answer": 1,
+    "hint": "It records operation traces.",
+    "elaboration": "torch.autograd.profiler helps identify time and memory hotspots. It records detailed traces of operations for optimization."
+  },
+  {
+    "question": "NVTX ranges inserted via torch.cuda.nvtx.range are primarily for",
+    "options": [
+      "Colorful traces in profiling tools",
+      "Batch size scaling",
+      "Error handling",
+      "Input normalization"
+    ],
+    "answer": 0,
+    "hint": "They annotate events on the timeline.",
+    "elaboration": "NVTX ranges create colorful traces for profiling tools. They mark regions of code to visualize in tools like Nsight or Chrome tracing."
+  }
+]

--- a/lessons/tokenizers.json
+++ b/lessons/tokenizers.json
@@ -1,0 +1,122 @@
+[
+  {
+    "question": "Byte pair encoding (BPE) works by",
+    "options": [
+      "Merging frequent pairs of symbols",
+      "Initializing weights",
+      "Sorting dataset files",
+      "Applying dropout"
+    ],
+    "answer": 0,
+    "hint": "It repeatedly joins the most common pairs.",
+    "elaboration": "BPE builds a vocabulary by iteratively merging the most frequent adjacent characters or bytes."
+  },
+  {
+    "question": "SentencePiece can operate directly on",
+    "options": [
+      "Raw text without pretokenization",
+      "GPU tensors",
+      "HTML pages",
+      "Graphical images"
+    ],
+    "answer": 0,
+    "hint": "No language-specific tokenizer needed first.",
+    "elaboration": "SentencePiece learns subword units from raw text, avoiding the need for prior tokenization or language rules."
+  },
+  {
+    "question": "A larger vocabulary size generally means",
+    "options": [
+      "Shorter sequences of tokens",
+      "Fewer model parameters",
+      "Lower memory usage",
+      "No subwords"
+    ],
+    "answer": 0,
+    "hint": "More words are captured as single tokens.",
+    "elaboration": "With more vocabulary tokens, text can be represented in fewer tokens on average, though embeddings grow."
+  },
+  {
+    "question": "Tokenization affects",
+    "options": [
+      "How the model sees text input",
+      "GPU clock speed",
+      "Color rendering",
+      "Kernel version"
+    ],
+    "answer": 0,
+    "hint": "It's the first step before encoding.",
+    "elaboration": "The choice of tokenization determines how words and characters are split into model inputs."
+  },
+  {
+    "question": "Detokenization refers to",
+    "options": [
+      "Converting tokens back to text",
+      "Removing dropout",
+      "Halting training",
+      "Resetting weights"
+    ],
+    "answer": 0,
+    "hint": "Reverse of the encoding step.",
+    "elaboration": "After generation, tokens are mapped back into human-readable text through the detokenization process."
+  },
+  {
+    "question": "Subword tokenization helps handle",
+    "options": [
+      "Rare or unseen words",
+      "More consistent capitalization",
+      "Precise whitespace removal",
+      "Fixed-length n-grams"
+    ],
+    "answer": 0,
+    "hint": "Break words into pieces.",
+    "elaboration": "By representing words as smaller units, subword methods can encode new or rare words not seen during training."
+  },
+  {
+    "question": "The BOS token stands for",
+    "options": [
+      "Beginning of sequence",
+      "Batch of samples",
+      "Binary optimized source",
+      "Base operating system"
+    ],
+    "answer": 0,
+    "hint": "It marks where text starts.",
+    "elaboration": "Special tokens like BOS and EOS delimit the start and end of sequences for the model."
+  },
+  {
+    "question": "Unigram language model tokenization chooses",
+    "options": [
+      "A probabilistic set of subwords",
+      "Only whole words",
+      "GPU-friendly binaries",
+      "Deterministic rounding"
+    ],
+    "answer": 0,
+    "hint": "It selects a vocabulary by likelihood.",
+    "elaboration": "The unigram model in SentencePiece picks subword units based on maximizing overall data likelihood."
+  },
+  {
+    "question": "When a tokenizer is poorly aligned with the data, models may",
+    "options": [
+      "Waste capacity modeling bad splits",
+      "Train faster automatically",
+      "Require no embeddings",
+      "Run at infinite speed"
+    ],
+    "answer": 0,
+    "hint": "Bad segmentation hurts efficiency.",
+    "elaboration": "Misaligned tokenization can produce awkward splits that the model wastes parameters on, reducing quality."
+  },
+  {
+    "question": "Tokenizer training often involves",
+    "options": [
+      "Building a vocabulary from representative text",
+      "Learning token embeddings",
+      "Estimating morphological rules",
+      "Compressing model checkpoints"
+    ],
+    "answer": 0,
+    "hint": "Collect text and find frequent patterns.",
+    "elaboration": "To create a tokenizer, a corpus is analyzed to learn which subwords or symbols should make up the vocabulary."
+  }
+]

--- a/style.css
+++ b/style.css
@@ -226,3 +226,99 @@ body {
 .scoreboard-toggle:hover {
     box-shadow: 0 0 5px var(--accent-color), 0 0 10px var(--accent-color);
 }
+
+/* Tabs */
+.tabs {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 1rem;
+    gap: 0.5rem;
+}
+
+.tab-link {
+    padding: 0.5rem 1rem;
+    background: var(--button-bg);
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.tab-link.active {
+    background: var(--accent-color);
+    color: var(--accent-text-color);
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+/* Lesson subtabs */
+.lessons {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: center;
+}
+
+.lesson-header {
+    background: var(--button-bg);
+    padding: 0.5rem 1rem;
+    border-radius: 5px;
+    cursor: pointer;
+    width: 90%;
+    max-width: 500px;
+    text-align: center;
+}
+
+.lesson-header.active {
+    background: var(--accent-color);
+    color: var(--accent-text-color);
+}
+
+.lesson-content {
+    display: none;
+    width: 100%;
+}
+
+.gallery {
+    display: flex;
+    overflow-x: auto;
+    gap: 1rem;
+    padding: 1rem 0;
+}
+
+.qa-card {
+    background: var(--tile-bg);
+    box-shadow: 0 0 5px var(--accent-color);
+    border-radius: 10px;
+    padding: 1rem;
+    min-width: 280px;
+    flex-shrink: 0;
+}
+
+.qa-card .question {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.qa-card .option {
+    margin: 0.25rem 0;
+    padding: 0.25rem;
+    background: var(--button-bg);
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.qa-card .option:hover {
+    background: var(--accent-color);
+    color: var(--accent-text-color);
+}
+
+.qa-card .result {
+    margin-top: 0.5rem;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add second tab "The Science Behind LLM Breakthroughs" with collapsible subtabs
- create gallery-style layouts for lesson quizzes
- extract tokenizers and PyTorch resource accounting data to separate files
- add new hyperparameters questions
- implement tab/lesson logic in JavaScript and update styles

## Testing
- `python -m json.tool lessons/tokenizers.json`
- `python -m json.tool lessons/pytorch_resource_accounting.json`
- `python -m json.tool lessons/hyperparameters.json`


------
https://chatgpt.com/codex/tasks/task_e_686dd9fcebac8320b1a95aa609808ffb